### PR TITLE
Category endpoint updates to support getting top level categories per site and filter queries

### DIFF
--- a/opencommercesearch-api/app/org/opencommercesearch/api/service/MongoStorage.scala
+++ b/opencommercesearch-api/app/org/opencommercesearch/api/service/MongoStorage.scala
@@ -350,6 +350,13 @@ class MongoStorage(mongo: MongoClient) extends Storage[WriteResult] {
     }
   }
 
+  def findAllCategories(fields: Seq[String]) : Future[Iterable[Category]] = {
+    Future {
+      val categoryCollection = jongo.getCollection("categories")
+      categoryCollection.find().projection(projectionCategory(fields)).as(classOf[Category])
+    }
+  }
+
   def findCategories(ids: Iterable[String], fields: Seq[String]) : Future[Iterable[Category]] = {
     Future {
         val categoryCollection = jongo.getCollection("categories")

--- a/opencommercesearch-api/app/org/opencommercesearch/api/service/Storage.scala
+++ b/opencommercesearch-api/app/org/opencommercesearch/api/service/Storage.scala
@@ -113,6 +113,13 @@ trait Storage[T] {
   def findCategory(id: String, fields: Seq[String]) : Future[Category]
 
   /**
+   * Find all existing categories from storage.
+   * @param fields List of fields that should be retrieved.
+   * @return Collection of category objects populated with storage data.
+   */
+  def findAllCategories(fields: Seq[String]) : Future[Iterable[Category]]
+
+  /**
    * Find all given category ids.
    * @param ids A collection of category ids to look for.
    * @param fields List of fields that should be retrieved.

--- a/opencommercesearch-api/app/org/opencommercesearch/api/util/Util.scala
+++ b/opencommercesearch-api/app/org/opencommercesearch/api/util/Util.scala
@@ -30,7 +30,6 @@ import play.api.i18n.Messages
  */
 object Util {
 
-
   val RESOURCE_CRUMB = "crumb"
   val ResourceInRange = "inrange"
   val ResourceBefore = "before"

--- a/opencommercesearch-api/conf/routes
+++ b/opencommercesearch-api/conf/routes
@@ -4,7 +4,7 @@
 
 # brand routes
 GET           /v1/brands/suggestions                                     org.opencommercesearch.api.controllers.BrandController.findSuggestions(version: Int = 1, q: String, preview: Boolean ?= false)
-GET           /v1/brand/categories                                        org.opencommercesearch.api.controllers.BrandController.findBrandCategories(version: Int = 1, preview: Boolean ?= false, site: String)
+GET           /v1/brand/categories                                       org.opencommercesearch.api.controllers.BrandController.findBrandCategories(version: Int = 1, preview: Boolean ?= false, site: String)
 GET           /v1/brands/:id                                             org.opencommercesearch.api.controllers.BrandController.findById(version: Int = 1, id: String, preview: Boolean ?= false)
 GET           /v1/brands/:id/categories                                  org.opencommercesearch.api.controllers.BrandController.findBrandCategoriesById(version: Int = 1, id: String, preview: Boolean ?= false, site: String)
 GET           /v1/brands                                                 org.opencommercesearch.api.controllers.BrandController.findAll(version: Int = 1, preview: Boolean ?= false, site: String)
@@ -25,6 +25,7 @@ DELETE        /v1/products/:id                                           org.ope
 
 # category routes
 GET           /v1/categories/suggestions                                 org.opencommercesearch.api.controllers.CategoryController.findSuggestions(version: Int = 1, q: String, site: String, preview: Boolean ?= false)
+GET           /v1/categories                                             org.opencommercesearch.api.controllers.CategoryController.findBySite(version: Int = 1, site: String, preview: Boolean ?= false)
 GET           /v1/categories/:id                                         org.opencommercesearch.api.controllers.CategoryController.findById(version: Int = 1, id: String, preview: Boolean ?= false)
 PUT           /v1/categories                                             org.opencommercesearch.api.controllers.CategoryController.bulkCreateOrUpdate(version: Int = 1, preview: Boolean ?= false)
 DELETE        /v1/categories                                             org.opencommercesearch.api.controllers.CategoryController.deleteByTimestamp(version: Int = 1, feedTimestamp: Long, preview: Boolean ?= false)

--- a/opencommercesearch-api/project/Build.scala
+++ b/opencommercesearch-api/project/Build.scala
@@ -36,7 +36,7 @@ object ApplicationBuild extends Build {
     resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases",
     organization  := "org.opencommercesearch",
     publishMavenStyle := true,
-    publishTo <<= (version) { version: String =>
+    publishTo <<= version { version: String =>
        val scalasbt = "http://repo.scala-sbt.org/scalasbt/"
        val (name, url) = if (version.contains("-SNAPSHOT"))
          ("sbt-plugin-snapshots-pub", scalasbt+"sbt-plugin-snapshots/")
@@ -48,5 +48,4 @@ object ApplicationBuild extends Build {
     jacoco.reportFormats in jacoco.Config := Seq(HTMLReport("utf-8")),
     jacoco.excludes in jacoco.Config := Seq("views*", "*Routes*", "*controllers*routes*", "*controllers*Reverse*", "*controllers*javascript*", "*controller*ref*", "*Controller")
   )
-
 }

--- a/opencommercesearch-api/project/plugins.sbt
+++ b/opencommercesearch-api/project/plugins.sbt
@@ -4,7 +4,6 @@ logLevel := Level.Warn
 // The Typesafe repository 
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.1")
 


### PR DESCRIPTION
Category endpoint updates to support getting top level categories per site and filter queries
Added statsd tracking for important methods, performance improvement - prune and copy fields recursively, split get top level categories by site and get category by id in two endpoints, minor refactors
Adding tests
