### PR TITLE
Changed where the name property is read from for facets

### DIFF
--- a/opencommercesearch-common/src/main/java/org/opencommercesearch/feed/FacetFeed.java
+++ b/opencommercesearch-common/src/main/java/org/opencommercesearch/feed/FacetFeed.java
@@ -55,7 +55,7 @@ public class FacetFeed extends BaseRestFeed {
         String facetType = (String) facet.getPropertyValue(FacetProperty.TYPE);
 
         facetJsonObj.put(FacetConstants.FIELD_ID, facet.getRepositoryId());
-        facetJsonObj.put(FacetConstants.FIELD_NAME, facet.getItemDisplayName());
+        facetJsonObj.put(FacetConstants.FIELD_NAME, facet.getPropertyValue(FacetProperty.NAME));
         facetJsonObj.put(FacetConstants.FIELD_FIELD_NAME, facet.getPropertyValue(FacetProperty.FIELD));
         facetJsonObj.put(FacetConstants.FIELD_TYPE, facetType);
         facetJsonObj.put(FacetConstants.FIELD_UI_TYPE, facet.getPropertyValue(FacetProperty.UI_TYPE));


### PR DESCRIPTION
Fixing bug in facet feed where name was set to the repository item display name, which in some cases is not  "user friendly".
