### PR TITLE
Prevent empty suggestion batches from being sent

### DIFF
--- a/opencommercesearch-api/app/org/opencommercesearch/search/suggester/IndexableElement.scala
+++ b/opencommercesearch-api/app/org/opencommercesearch/search/suggester/IndexableElement.scala
@@ -120,7 +120,12 @@ object IndexableElement {
           s.toSolrDoc(feedTimeStamp)
         })
 
-        updateQuery.process(solrServer)
+        if(updateQuery.getDocuments.size() > 0) {
+          updateQuery.process(solrServer)
+        }
+        else {
+          Future(null)
+        }
       }
     }
     else {


### PR DESCRIPTION
If you called Indexableelement.addToIndex with an empty sequence of suggestions, Solr would return an errors because no docs were sent. 

This change is to ignore empty suggestion batches in such cases.
