### PR TITLE
Count all products in a batch as feed errors

### DIFF
--- a/opencommercesearch-atg-common/src/main/java/org/opencommercesearch/feed/SearchFeedProducts.java
+++ b/opencommercesearch-atg-common/src/main/java/org/opencommercesearch/feed/SearchFeedProducts.java
@@ -45,6 +45,19 @@ public class SearchFeedProducts {
         return productsByLocale.get(locale);
     }
 
+    /**
+     * Gets the total product count in the current instance, considering all locales.
+     * @return Total product count in the current instance (counts all locales).
+     */
+    public int getProductCount() {
+        int count = 0;
+        for(Locale locale : getLocales()) {
+            count += productsByLocale.get(locale).size();
+        }
+
+        return count;
+    }
+
     public int getSkuCount(Locale locale) {
         int count = 0;
         for (Product p : productsByLocale.get(locale)) {


### PR DESCRIPTION
At the moment, product errors were count once per every batch. In case of disaster, that would prevent the threshold to be reached and the feed from stopping as expected.
