### PR TITLE
Refactor rule category field to extract paths calculation to API

### DIFF
--- a/opencommercesearch-api/app/org/opencommercesearch/api/controllers/RuleController.scala
+++ b/opencommercesearch-api/app/org/opencommercesearch/api/controllers/RuleController.scala
@@ -23,21 +23,24 @@ import play.api.libs.concurrent.Execution.Implicits._
 import play.api.mvc._
 import play.api.Logger
 import play.api.libs.json.{JsError, JsArray, Json}
-
 import scala.concurrent.Future
-
 import org.opencommercesearch.api.Global._
 import org.opencommercesearch.api.util.Util
-import org.opencommercesearch.api.models.{Rule, RuleList}
+import org.opencommercesearch.api.models.{Category, Rule, RuleList}
 import org.apache.solr.client.solrj.request.AsyncUpdateRequest
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.client.solrj.request.AbstractUpdateRequest.ACTION
 import org.apache.solr.client.solrj.beans.BindingException
 import org.apache.solr.common.SolrDocument
 import Util._
+import org.opencommercesearch.api.service.CategoryService
+import org.opencommercesearch.api.service.CategoryService.Taxonomy
+import scala.util.Success
 
 object RuleController extends BaseController {
 
+  var categoryService = new CategoryService(solrServer, storageFactory)
+  
   def findById(version: Int, id: String, preview: Boolean) = Action.async { implicit request =>
     val query = withRuleCollection(withFields(new SolrQuery(), request.getQueryString("fields")), preview, request.acceptLanguages)
 
@@ -90,36 +93,36 @@ object RuleController extends BaseController {
     }.get
   }
 
-  def bulkCreateOrUpdate(version: Int, preview: Boolean) = Action.async (parse.json(maxLength = 1024 * 2000)) { request =>
-    Json.fromJson[RuleList](request.body).map { ruleList =>
+  def bulkCreateOrUpdate(version: Int, preview: Boolean) = ContextAction.async (parse.json(maxLength = 1024 * 2000)) { 
+    implicit context => request =>
+      Json.fromJson[RuleList](request.body).map { ruleList =>
       val rules = ruleList.rules
-      try {
         if (rules.length > MaxRuleIndexBatchSize) {
           Future.successful(BadRequest(Json.obj(
             "message" -> s"Exceeded number of Rules. Maximum is $MaxRuleIndexBatchSize")))
         } else {
           val update = withRuleCollection(new AsyncUpdateRequest(), preview, request.acceptLanguages)
-          rules map { rule =>
-              update.add(solrServer.binder.toSolrInputDocument(rule))
-          }
-
-          val future: Future[SimpleResult] = update.process(solrServer).map( response => {
-            Created(Json.obj(
-              "locations" -> JsArray(
-                rules map (b => Json.toJson(routes.RuleController.findById(b.id.get).url))
-              )))
+          val storage = withNamespace(storageFactory)
+          
+          val future = categoryService.getTaxonomy(storage, context.isPreview).flatMap(taxonomy => {
+            rules.foreach(rule => {
+                if (rule.category != null && rule.category.isDefined) {
+                    val categoryPaths = rule.getCategory.flatMap({ categoryId => ruleCategoryPathMapper(categoryId, taxonomy) })
+                    rule.category = Option(categoryPaths)
+                }
+                update.add(solrServer.binder.toSolrInputDocument(rule))
+              }
+            )
+            update.process(solrServer).map( response => {
+                    Created(Json.obj(
+                      "locations" -> JsArray(
+                        rules map (b => Json.toJson(routes.RuleController.findById(b.id.get).url))
+                      )))
+            }) 
           })
-
+          
           withErrorHandling(future, s"Cannot store Rules with ids [${rules map (_.id.get) mkString ","}]")
         }
-      }
-      catch {
-        case e : BindingException =>
-          //Handle bind exceptions
-          Future.successful(BadRequest(Json.obj(
-            "message" -> s"Illegal Rule fields [${rules map (_.id.get) mkString ","}] ",
-            "detail" -> e.getMessage)))
-      }
     }.recover {
       case e => Future.successful(BadRequest(Json.obj(
         // @TODO figure out how to pull missing field from JsError
@@ -128,6 +131,24 @@ object RuleController extends BaseController {
     }.get
   }
 
+  /**
+   * Helper method that maps a given category id to it's corresponding 
+   * set of category paths using both, the namePath and the idPath formats
+   * @param The id of the category to lookup in the taxonomy
+   * @param the object holding the taxonomy
+   */
+  private def ruleCategoryPathMapper(category: String, taxonomy: Taxonomy) : Seq[String] = {
+    val categoryObj = taxonomy.get(category)
+    if ("__all__".equals(category)) {
+      Seq("__all__")
+    } else if(categoryObj != null && categoryObj.isDefined) {
+      val paths = categoryService.getPaths(categoryObj.get, taxonomy)
+      paths.map(f =>  f.idPath) ++ paths.map(f => f.namePath)
+    } else {
+      Seq.empty
+    }
+  }
+  
   /**
    * Post method for the rules endpoint. Will send commit or rollback to Solr accordingly.
    * @param commit true if a commit should be done.

--- a/opencommercesearch-api/app/org/opencommercesearch/api/service/CategoryService.scala
+++ b/opencommercesearch-api/app/org/opencommercesearch/api/service/CategoryService.scala
@@ -69,6 +69,11 @@ class CategoryService(var server: AsyncSolrServer, var storageFactory: MongoStor
   private val StatsdPruneTaxonomyGraphMetric = "api.search.internal.service.pruneTaxonomyGraph"
 
   /**
+   * Case class to hold the searchTokens and categoryPath fields for a given category
+   */
+  case class Path(namePath: String, idPath: String)
+  
+  /**
    * Generate the category tokens to create a hierarchical facet in Solr. Each
    * token is formatted such that encodes the depth information for each node
    * that appears as part of the path, and include the hierarchy separated by
@@ -481,6 +486,35 @@ class CategoryService(var server: AsyncSolrServer, var storageFactory: MongoStor
     }
   }
 
+  /**
+   * Get all the paths from the top of the taxonomy to a given category.
+   * These paths are in the format of searchTokens (1.site.category name.subcat name) and categoryPaths
+   * (site.categoryId.subcategoryId)
+   * @param currentCategory  the category to generate the paths from
+   * @param taxonomy the taxonomy obj which holds the entire site taxonomy
+   */
+  def getPaths(currentCategory: Category, taxonomy: Taxonomy): Seq[Path] = {
+    return getPaths(currentCategory, taxonomy, Seq.empty, 0) 
+  }
+  
+  private def getPaths(currentCategory: Category, taxonomy: Taxonomy, path: Seq[Path], depth: Int): Seq[Path] = {
+        if(currentCategory == null || currentCategory.parentCategories.getOrElse(Seq.empty).isEmpty) {
+          return path match {
+            case x :: xs => (path.map (p => new Path(depth + "." + currentCategory.sites.getOrElse(Seq("")).last + "." + p.namePath, 
+                                     currentCategory.sites.getOrElse(Seq("")).last + "." + p.idPath)))
+            case _ =>  (Seq.empty)  
+          }
+        } 
+        currentCategory.parentCategories.get.flatMap(parentCat => {
+          val paths = path match {
+            case x :: xs => (path.map (p => new Path(currentCategory.getName + "." + p.namePath,
+                                 currentCategory.getId + "." + p.idPath)))
+            case Nil =>  (Seq(new Path(currentCategory.getName, currentCategory.getId)))
+          }
+          
+          return getPaths(taxonomy.get(parentCat.getId).getOrElse(null), taxonomy, paths, depth + 1)
+        })
+      }
   /**
    * Scans the taxonomy to find the root nodes. Root nodes are inserted into the map with the site id as key.
    *

--- a/opencommercesearch-api/test/org/opencommercesearch/api/controllers/RuleControllerSpec.scala
+++ b/opencommercesearch-api/test/org/opencommercesearch/api/controllers/RuleControllerSpec.scala
@@ -23,9 +23,7 @@ import play.api.mvc.SimpleResult
 import play.api.test._
 import play.api.test.Helpers._
 import play.api.libs.json.{JsError, Json, JsArray}
-
 import scala.concurrent.Future
-
 import org.specs2.mutable._
 import org.specs2.mock.Mockito
 import org.apache.solr.client.solrj.impl.AsyncCloudSolrServer
@@ -34,17 +32,38 @@ import org.apache.solr.client.solrj.response.QueryResponse
 import org.apache.solr.common.util.NamedList
 import org.apache.solr.common.{SolrDocumentList, SolrDocument}
 import org.opencommercesearch.api.models.Rule
-
 import org.opencommercesearch.api.Global._
 import org.apache.solr.client.solrj.beans.DocumentObjectBinder
 import org.opencommercesearch.api.service.{MongoStorage, MongoStorageFactory}
+import org.junit.runner.RunWith
+import org.specs2.runner.JUnitRunner
+import org.opencommercesearch.api.service.CategoryService
+import org.opencommercesearch.api.service.Storage
+import org.opencommercesearch.api.models.Category
 
+
+@RunWith(classOf[JUnitRunner])
 class RuleControllerSpec extends Specification with Mockito {
 
   trait Rules extends Before {
     def before = {
       solrServer = mock[AsyncCloudSolrServer]
       storageFactory = mock[MongoStorageFactory]
+      val categoryService = mock[CategoryService]
+      val taxonomy = mock[CategoryService.Taxonomy]
+      taxonomy.get(anyString) answers { catId => {
+          if ("__all__".equals(catId)) { None }
+          else {
+            val category = Category.getInstance(Some(catId.toString))
+            category.isRuleBased = Option(false)
+            category.sites = Option(Seq("mysite"))
+            category.hierarchyTokens = Option(Seq("2.mysite.category.subcategory"))
+            Option(category)
+          }
+        }
+      }
+      categoryService.getTaxonomy(any[MongoStorage], any)  returns Future.successful(taxonomy)
+      RuleController.categoryService = categoryService
       storageFactory.getInstance(anyString) returns mock[MongoStorage]
     }
   }
@@ -197,7 +216,7 @@ class RuleControllerSpec extends Specification with Mockito {
 
         val response = route(fakeRequest)
         validateFailedUpdate(updateResponse)
-        validateUpdateResultWithMessage(response.get, BAD_REQUEST, "Illegal Rule fields")
+        validateUpdateResultWithMessage(response.get, BAD_REQUEST, "Illegal fields")
       }
     }
 
@@ -279,6 +298,7 @@ class RuleControllerSpec extends Specification with Mockito {
                 "\"sortPriority\": 0," +
                 "\"query\": \"[purses on sale]\"," +
                 "\"catalogId\": [\"__all__\"]," +
+                "\"category\": [\"__all__\"]," +
                 "\"brandId\": [\"__all__\"]," +
                 "\"experimental\": false," +
                 "\"target\": [\"searchpages\"]," +

--- a/opencommercesearch-atg-common/src/test/java/org/opencommercesearch/feed/RuleFeedTest.java
+++ b/opencommercesearch-atg-common/src/test/java/org/opencommercesearch/feed/RuleFeedTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.opencommercesearch.RuleConstants;
 import org.opencommercesearch.RuleManager;
 import org.opencommercesearch.RulesBuilder;
 import org.opencommercesearch.Utils;
@@ -129,9 +130,12 @@ public class RuleFeedTest {
 
         // cateCchildx search tokens...
         when(cateCchild1.getPropertyValue(CategoryProperty.SEARCH_TOKENS)).thenReturn(new HashSet<String>(Arrays.asList(new String[]{ "cateCchild1:token", })));
+        when(cateCchild1.getRepositoryId()).thenReturn("cate:charlie:child1");
         when(cateCchild2.getPropertyValue(CategoryProperty.SEARCH_TOKENS)).thenReturn(new HashSet<String>(Arrays.asList(new String[]{ "cateCchild2:token", })));
+        when(cateCchild2.getRepositoryId()).thenReturn("cate:charlie:child2");
         when(cateCchild3.getPropertyValue(CategoryProperty.SEARCH_TOKENS)).thenReturn(new HashSet<String>(Arrays.asList(new String[]{ "cateCchild3:token:INVISIBLE!!!!", })));
-
+        when(cateCchild3.getRepositoryId()).thenReturn("cate:charlie:child3");
+        
         // cateCchild1childx search tokens...
         when(cateCchild1child1.getPropertyValue(CategoryProperty.SEARCH_TOKENS)).thenReturn(new HashSet<String>(Arrays.asList(new String[]{ "cateCchild1.cateCchild1child1:token", })));
         when(cateCchild1child2.getPropertyValue(CategoryProperty.SEARCH_TOKENS)).thenReturn(new HashSet<String>(Arrays.asList(new String[]{ "cateCchild1.cateCchild1child2:token", })));
@@ -162,12 +166,9 @@ public class RuleFeedTest {
 
         ruleFeed = new RuleFeed();
         JSONObject doc = ruleFeed.repositoryItemToJson(testRuleItem);
-        Set<String> paths = new HashSet<String>();
-        paths.add("cataC.cateCchild3");
-        paths.add("cataB.cateCchild3");
         List<String> calculatedPaths = (List<String>)doc.get("category");
-        assertEquals(paths.toArray()[0], calculatedPaths.get(0));
-        assertEquals(paths.toArray()[1], calculatedPaths.get(1));
+        assertEquals("cateCchild3", calculatedPaths.get(0));
+        assertEquals(1, calculatedPaths.size());
     }
 
     @Test
@@ -261,11 +262,12 @@ public class RuleFeedTest {
         JSONArray categories = (JSONArray) doc.get("category");
         List<String> categoryList = Lists.newArrayList(categories);
         for (String token : new String[] {
-                "cateA:token1",
-                "cateA:token2",
-                "cateB:token",
-                "cateCchild1:token",
-                "cateCchild2:token",
+                "cate:alpha",
+                "cate:beta",
+                "cate:charlie",
+                "cate:charlie:child1",
+                "cate:charlie:child2",
+                "cate:charlie:child3",
         }) {
             assertThat(categoryList, CoreMatchers.hasItem(token));
         }
@@ -440,19 +442,16 @@ public class RuleFeedTest {
         when(cataB.getRepositoryId()).thenReturn("cataB");
 
         JSONObject doc = ruleFeed.repositoryItemToJson(testRuleItem);
-        List<String> calculatedPaths = (List<String>)doc.get("category");
-        assertEquals("cateCchild1:token", calculatedPaths.get(0));
-        assertEquals("cateCchild1.cateCchild1child1:token", calculatedPaths.get(1));
-        assertEquals("cateCchild1.cateCchild1child2:token", calculatedPaths.get(2));
-        assertEquals("cateCchild1.cateCchild1child3:token", calculatedPaths.get(3));
-        assertEquals("cataC.cateCchild1", calculatedPaths.get(4));
-        assertEquals("cataB.cateCchild1", calculatedPaths.get(5));
-        assertEquals("cataC.cateCchild1.cateCchild1child1", calculatedPaths.get(6));
-        assertEquals("cataB.cateCchild1.cateCchild1child1", calculatedPaths.get(7));
-        assertEquals("cataC.cateCchild1.cateCchild1child2", calculatedPaths.get(8));
-        assertEquals("cataB.cateCchild1.cateCchild1child2", calculatedPaths.get(9));
-        assertEquals("cataC.cateCchild1.cateCchild1child3", calculatedPaths.get(10));
-        assertEquals("cataB.cateCchild1.cateCchild1child3", calculatedPaths.get(11));
+        
+        List<String> categoryList = (List<String>) doc.get("category");
+        for (String token : new String[] {
+                "cateCchild1",
+                "cateCchild1child1",
+                "cateCchild1child2",
+                "cateCchild1child3"
+        }) {
+            assertThat(categoryList, CoreMatchers.hasItem(token));
+        }
     }
 
     @Test
@@ -469,8 +468,7 @@ public class RuleFeedTest {
 
         JSONObject doc = ruleFeed.repositoryItemToJson(testRuleItem);
         List<String> calculatedPaths = (List<String>)doc.get("category");
-        assertEquals("cateCchild1:token", calculatedPaths.get(0));
-        assertEquals("cataC.cateCchild1", calculatedPaths.get(1));
-        assertEquals("cataB.cateCchild1", calculatedPaths.get(2));
+        assertEquals("cateCchild1", calculatedPaths.get(0));
+        assertEquals(1, calculatedPaths.size());
     }
 }

--- a/opencommercesearch-solr/src/main/java/org/opencommercesearch/RuleConstants.java
+++ b/opencommercesearch-solr/src/main/java/org/opencommercesearch/RuleConstants.java
@@ -152,6 +152,12 @@ public class RuleConstants {
      * to find out what's the current category.
      */
     public static final String FIELD_ANCESTOR_CATEGORY = "ancestorCategoryId";
+    
+    /**
+     * Flag to indicate if the rule should include all the children categories from the ones in the 
+     * category field
+     */
+    public static final String FIELD_INCLUDE_SUBCATEGORIES = "includeSubcategories";
 
     /**
      * Combine mode value that when specified replaces all existing rule values of the same type.


### PR DESCRIPTION
It was calculated with the category paths and search tokens in the RuleFeed.  Moved this logic to the API.

Now it only receives a list of category ids and the category paths as well as the search tokens are calculated in the API
