### PR TITLE
Spell check support on search responses

### DIFF
--- a/opencommercesearch-api/app/org/opencommercesearch/api/Global.scala
+++ b/opencommercesearch-api/app/org/opencommercesearch/api/Global.scala
@@ -44,7 +44,7 @@ object Global extends WithFilters(new StatsdFilter(), new GzipFilter(), AccessLo
   lazy val MaxProductIndexBatchSize = getConfig("index.product.batchsize.max", 100)
   lazy val MaxCategoryIndexBatchSize = getConfig("index.category.batchsize.max", 100)
   lazy val MaxRuleIndexBatchSize = getConfig("index.rule.batchsize.max", 100)
-  lazy val MaxUpdateFacetBatchSize = getConfig("facet.maxUpdateBatchSize", 100)
+  lazy val MaxUpdateFacetBatchSize = getConfig("index.facet.batchsize.max", 100)
   // @todo deprecate category collections
   lazy val CategoryPreviewCollection = getConfig("preview.collection.category", "categoriesPreview")
   lazy val CategoryPublicCollection = getConfig("public.collection.category", "categoriesPublic")
@@ -60,6 +60,7 @@ object Global extends WithFilters(new StatsdFilter(), new GzipFilter(), AccessLo
   lazy val MinSuggestQuerySize = getConfig("suggester.query.size.min", 2)
   lazy val IndexOemProductsEnabled = getConfig("index.product.oem.enabled", default = false)
   lazy val ProductAvailabilityStatusSummary = availabilityStatusSummaryConfig
+  lazy val SpellCheckMinimumMatch = getConfig("spellcheck.minimummatch", "2<-1 3<-2 5<80%")
 
   // @todo evaluate using dependency injection, for the moment lets be pragmatic
   private var _solrServer: AsyncSolrServer = null

--- a/opencommercesearch-api/app/org/opencommercesearch/api/ProductQuery.scala
+++ b/opencommercesearch-api/app/org/opencommercesearch/api/ProductQuery.scala
@@ -84,6 +84,11 @@ sealed class ProductQuery(q: String, site: String = null)(implicit context: Cont
     this
   }
 
+  def withSpellCheck(enabled: Boolean = true) = {
+    this.setParam("spellcheck", enabled)
+    this
+  }
+
   def withFilterQueries() : ProductQuery = {
     _filterQueries = setFilterQueriesFor(this)
     this

--- a/opencommercesearch-api/app/org/opencommercesearch/api/controllers/CategoryController.scala
+++ b/opencommercesearch-api/app/org/opencommercesearch/api/controllers/CategoryController.scala
@@ -68,7 +68,7 @@ object CategoryController extends BaseController with FacetQuery {
       outlet: Boolean) = ContextAction.async {  implicit context => implicit request =>
 
     val startTime = System.currentTimeMillis()
-    val site = request.getQueryString("site").getOrElse(null)
+    val site = request.getQueryString("site").orNull
     val categoryFacetQuery = new ProductFacetQuery("categoryPath", site)
       .withAncestorCategory(id)
       .withFilterQueries()
@@ -271,7 +271,7 @@ object CategoryController extends BaseController with FacetQuery {
       NoContent
     })
 
-    withErrorHandling(future, s"Cannot delete product before feed timestamp [$feedTimestamp]")
+    withErrorHandling(future, s"Cannot delete categories before feed timestamp [$feedTimestamp]")
   }
 
   @ApiOperation(value = "Suggests categories", notes = "Returns category suggestions for given partial category name", response = classOf[Category], httpMethod = "GET")

--- a/opencommercesearch-api/app/org/opencommercesearch/api/controllers/ProductController.scala
+++ b/opencommercesearch-api/app/org/opencommercesearch/api/controllers/ProductController.scala
@@ -45,7 +45,7 @@ import org.opencommercesearch.search.suggester.IndexableElement
 
 import org.apache.commons.lang3.StringUtils
 import org.apache.solr.client.solrj.SolrQuery
-import org.apache.solr.client.solrj.response.{QueryResponse, UpdateResponse}
+import org.apache.solr.client.solrj.response.{SpellCheckResponse, GroupCommand, QueryResponse, UpdateResponse}
 import org.apache.solr.client.solrj.util.ClientUtils
 import org.apache.solr.common.util.NamedList
 
@@ -54,6 +54,9 @@ import com.wordnik.swagger.annotations._
 @Api(value = "products", basePath = "/api-docs/products", description = "Product API endpoints")
 object ProductController extends BaseController {
   val categoryService = new CategoryService(solrServer, storageFactory)
+
+  private val OrOperator = "OR"
+  private val AndOperator = "AND"
 
   @ApiOperation(value = "Searches products", notes = "Returns product information for a given product", response = classOf[Product], httpMethod = "GET")
   @ApiResponses(value = Array(new ApiResponse(code = 404, message = "Product not found")))
@@ -246,12 +249,11 @@ object ProductController extends BaseController {
     new JsObject(groups)
   }
 
-
   /**
    * Helper method to process search results
    * @param q is the query
    * @param response the Solr response
-   * @return a tuple with the total number of products found and the list of product documents in the response
+   * @return a tuple with the total number of products found and the list of product documents in the response and the group summary
    */
   private def processSearchResults[R](q: String, response: QueryResponse)(implicit context: Context, req: Request[R]) : Future[(Int, Iterable[Product], NamedList[Object])] = {
     val groupResponse = response.getGroupResponse
@@ -280,11 +282,11 @@ object ProductController extends BaseController {
             Future.successful((0, null, null))
           }
         } else {
-          Logger.debug(s"Unexpected response found for query $q")
+          Logger.debug(s"Unexpected response found for query '$q'")
           Future.successful((0, null, null))
         }
       } else {
-        Logger.debug(s"Unexpected response found for query $q")
+        Logger.debug(s"Unexpected response found for query '$q'")
         Future.successful((0, null, null))
       }
     } else {
@@ -311,9 +313,14 @@ object ProductController extends BaseController {
       site: String,
       @ApiParam(defaultValue="false", allowableValues="true,false", value = "Display outlet results", required = false)
       @QueryParam("outlet")
-      outlet: Boolean) = ContextAction.async { implicit context =>  implicit request =>
+      outlet: Boolean,
+      @ApiParam(defaultValue="auto", allowableValues="auto,yes,no", value = "Whether or not query spell checking should be done. If set to auto and the original " +
+        "query returns zero results, the search is retried with the spell check corrected terms. If set to yes, only correctedTerms and suggested terms is returned, no search is retried.", required = false)
+      @QueryParam("outlet")
+      spellCheckParam: String) = ContextAction.async { implicit context =>  implicit request =>
 
     val startTime = System.currentTimeMillis()
+    val spellCheckMode = spellCheckParam.toLowerCase
     val query = new ProductSearchQuery(q, site)
       .withFilterQueries()
       .withFaceting()
@@ -321,58 +328,223 @@ object ProductController extends BaseController {
       .withSorting()
       .withGrouping()
       .withOutlet()
+      .withSpellCheck(spellCheckMode != "no")
 
-    Logger.debug("Searching for " + q)
+    Logger.debug(s"Searching for '$q', spell checking set to '$spellCheckMode'")
 
-    val future: Future[SimpleResult] = solrServer.query(query).flatMap( response => {
+    val future = doSearch(query, spellCheckMode, startTime) flatMap { case (spellCheckResponse, response) =>
       val redirect = response.getResponse.get("redirect_url")
       if (redirect != null && StringUtils.isNotBlank(redirect.toString)) {
-         Future.successful(Ok(Json.obj(
-                "metadata" -> Json.obj(
-                  "redirectUrl" -> redirect.toString,
-                  "time" -> (System.currentTimeMillis() - startTime)
-         ))))
-      } else if (query.getRows > 0) {
+        Future.successful(buildSearchResponse(startTime = Some(startTime), redirectUrl = Some(redirect.toString)))
+      }
+      else if(query.getRows > 0) {
         processSearchResults(q, response).map { case (found, products, groupSummary) =>
           if (products != null) {
             if (found > 0) {
               val facetHandler = buildFacetHandler(response, query, query.filterQueries)
-              withCacheHeaders(Ok(Json.obj(
-                "metadata" -> Json.obj(
-                  "found" -> found,
-                  "time" -> (System.currentTimeMillis() - startTime),
-                  "productSummary" -> processGroupSummary(groupSummary),
-                  "facets" -> facetHandler.getFacets,
-                  "breadCrumbs" -> facetHandler.getBreadCrumbs),
-                "products" -> Json.toJson(
-                  products map (Json.toJson(_))
-                ))), products map (_.getId))
+              withCacheHeaders(buildSearchResponse(
+                breadCrumbs = Some(facetHandler.getBreadCrumbs),
+                facets = Some(facetHandler.getFacets),
+                found = Some(found),
+                productSummary = Some(processGroupSummary(groupSummary)),
+                spellCheck = Option(spellCheckResponse),
+                startTime = Some(startTime),
+                products = Some(products map (Json.toJson(_)))), products map (_.getId))
             } else {
-              Ok(Json.obj(
-                "metadata" -> Json.obj(
-                  "found" -> found,
-                  "time" -> (System.currentTimeMillis() - startTime)),
-                "message" -> "No products found"
-              ))
+              buildSearchResponse(
+                found = Some(found),
+                productSummary = Some(processGroupSummary(groupSummary)),
+                spellCheck = Option(spellCheckResponse),
+                startTime = Some(startTime),
+                message = Some("No products found"))
             }
           } else {
-            Logger.debug(s"Unexpected response found for query $q")
-            Ok(Json.obj(
-              "metadata" -> Json.obj(
-                "found" -> 0,
-                "time" -> (System.currentTimeMillis() - startTime)),
-              "message" -> "No products found"))
+            Logger.debug(s"No results found for query '${query.getQuery}', returning spell check suggestions if any.")
+            buildSearchResponse(found = Some(0), spellCheck =  Option(spellCheckResponse), startTime = Some(startTime), message = Some("No products found"))
           }
         }
       } else {
-        Future.successful(Ok(Json.obj(
-          "metadata" -> Json.obj(
-            "found" -> response.getResults.getNumFound,
-            "time" -> (System.currentTimeMillis() - startTime)))))
+        Future.successful(buildSearchResponse(found = Some(response.getResults.getNumFound), spellCheck = Option(spellCheckResponse), startTime = Some(startTime)))
       }
-    })
+    }
 
-    withErrorHandling(future, s"Cannot search for [$q]")
+    withErrorHandling(future, s"Cannot search for [${query.getQuery}]")
+  }
+
+  /**
+   * Does the actual search.
+   * @param query Original product query
+   * @param spellCheck Spell check setting (auto, yes, no)
+   * @param startTime Time when this search request started.
+   * @return A spellcheck response (can be null) and a query response.
+   */
+  def doSearch(query: ProductQuery, spellCheck: String, startTime: Long) : Future[(JsObject, QueryResponse)] = {
+    val q = query.getQuery
+
+    solrServer.query(query) flatMap { response =>
+      def isRedirect = {
+        val redirect = response.getResponse.get("redirect_url")
+        redirect != null && StringUtils.isNotBlank(redirect.toString)
+      }
+
+      if (spellCheck != "no" && query.getRows > 0 && StringUtils.isNotBlank(q) && !isRedirect && !hasResults(response)) {
+        //Do spellchecking
+        if (spellCheck == "auto") {
+          handleSpellCheck(query, response)
+        }
+        else {
+          //Return spell check suggestions is any, let the client handle it.
+          Future((spellCheckToJson(response.getSpellCheckResponse), response))
+        }
+      }
+      else {
+        Future((null, response))
+      }
+    }
+  }
+
+  /**
+   * Converts from Solr spell check response to Json (called when spellcheck=true)
+   * @param spellCheckResponse Solr spell check response
+   * @return A Json object in the appropiate format.
+   */
+  private def spellCheckToJson(spellCheckResponse: SpellCheckResponse) : JsObject = {
+    if(spellCheckResponse != null) {
+      Json.obj(
+        "terms" -> spellCheckResponse.getSuggestions.map({suggestion =>
+          Json.obj(
+            "term" -> suggestion.getToken,
+            "found" -> suggestion.getNumFound,
+            "startOffset" -> suggestion.getStartOffset,
+            "endOffset" -> suggestion.getEndOffset,
+            "suggestions" -> suggestion.getAlternatives.toIterable
+          )}),
+        "collation" -> spellCheckResponse.getCollatedResult
+      )
+    }
+    else {
+      null
+    }
+  }
+
+  /**
+   * Retries the search with the best spell check suggestion (if any). If that doesn't give results, then try again matching any term (by default, Solr results must match ALL terms in
+   * the query).
+   * @param query A query that returned zero results.
+   * @param response The response of the given query
+   * @param queryOp The query operator to use. The default value is 'AND', which will match all terms in the query. Can also use 'OR', to match any term in the query.
+   * @return The best query response. If spell checking didn't return anything useful, it returns the original query response.
+   */
+  private def handleSpellCheck(query: ProductQuery, response: QueryResponse, queryOp: String = AndOperator) : Future[(JsObject, QueryResponse)] = {
+    val spellCheckResponse = response.getSpellCheckResponse
+
+    if (spellCheckResponse != null && StringUtils.isNotBlank(spellCheckResponse.getCollatedResult)) {
+      //Check if we have any spelling suggestion
+      val tentativeQuery = spellCheckResponse.getCollatedResult
+
+      //if we have spelling suggestions, try doing another search using
+      //q.op as the specified queryOp param (the default one is AND so we only add it if it's OR)
+      //and use q="corrected phrase" to see if we can get results
+      if (OrOperator == queryOp) {
+        query.setParam("q.op", OrOperator)
+        query.setParam("mm", SpellCheckMinimumMatch)
+      }
+
+      query.setQuery(tentativeQuery)
+      Logger.debug(s"Searching spell check suggestion '$tentativeQuery' with query operator '$queryOp'")
+      solrServer.query(query) flatMap { tentativeResponse =>
+        if(!hasResults(tentativeResponse)) {
+          handleSpellCheck(query, tentativeResponse, OrOperator)
+        } else {
+          if(OrOperator == queryOp) {
+            Future(Json.obj(
+              "correctedTerms" -> tentativeQuery,
+              "similarResults" -> true), tentativeResponse)
+          }
+          else {
+            Future(Json.obj(
+              "correctedTerms" -> tentativeQuery), tentativeResponse)
+          }
+        }
+      }
+    } else if(OrOperator == queryOp) {
+        //for the match any terms scenario with no corrected terms do another query
+        query.setParam("q.op", OrOperator)
+        query.setParam("mm", SpellCheckMinimumMatch)
+
+        Logger.debug(s"Searching spell check suggestion '${query.getQuery}' with query operator '$queryOp'")
+        solrServer.query(query) map { tentativeResponse =>
+          if(hasResults(tentativeResponse)) {
+            val spellCheck = Json.obj(
+                "correctedTerms" -> query.getQuery,
+                "similarResults" -> true)
+
+            (spellCheck, tentativeResponse)
+          } else {
+            (null, response)
+          }
+        }
+    }
+    else {
+      //if we didn't got any corrected terms and are not in the match any term scenario,
+      //then return null
+      Future((null, response))
+    }
+  }
+
+  /**
+   * Helper method that constructs a search response
+   * @param found Number of search results found
+   * @param message Message to display in the response, if any.
+   * @param startTime The time when the search started.
+   * @return A simple result containing a proper search response body.
+   */
+  private def buildSearchResponse(
+                                   breadCrumbs: Option[Seq[BreadCrumb]] = None,
+                                   facets: Option[Seq[Facet]] = None,
+                                   found: Option[Long] = None,
+                                   productSummary: Option[JsObject] = None,
+                                   redirectUrl: Option[String] = None,
+                                   spellCheck: Option[JsObject] = None,
+                                   startTime: Option[Long] = None,
+                                   message: Option[String] = None,
+                                   products: Option[Iterable[JsValue]] = None) : SimpleResult = {
+
+    val metadataValues = Seq[Option[(String, JsValueWrapper)]](
+      redirectUrl map {v => "redirectUrl" ->  v},
+      found map {v => "found" -> v},
+      productSummary map {v => "productSummary" -> v},
+      startTime map {v => "time" -> (System.currentTimeMillis() - v)},
+      facets map {v => "facets" -> v},
+      breadCrumbs map {v => "breadCrumbs" -> v},
+      spellCheck map {v => "spellCheck" -> v}
+    )
+
+    val responseValues = Seq[Option[(String, JsValueWrapper)]](
+      Some("metadata" -> Json.obj(metadataValues.flatten:_*)),
+      message map {v => "message" -> v},
+      products map {v => "products" -> products}
+    )
+
+    Ok(Json.obj(responseValues.flatten:_*))
+  }
+
+  /**
+   * Helper method that tells if a Solr query response has results or not.
+   * @param response The Solr query response.
+   * @return True, if the response contains results,false otherwise.
+   */
+  private def hasResults(response: QueryResponse) : Boolean = {
+    if(response.getGroupResponse != null) {
+      val groupResponse = response.getGroupResponse
+
+      groupResponse.getValues.collectFirst({
+        case command: GroupCommand if command.getNGroups > 0 => true
+      }).getOrElse(false)
+    }
+    else {
+      response.getResults != null && response.getResults.getNumFound > 0
+    }
   }
 
   @ApiOperation(value = "Browses brand products ", notes = "Returns products for a given brand", response = classOf[Product], httpMethod = "GET")

--- a/opencommercesearch-api/conf/routes
+++ b/opencommercesearch-api/conf/routes
@@ -20,7 +20,7 @@ DELETE        /v1/brands                                                 org.ope
 
 # product routes
 GET           /v1/products/suggestions                                   org.opencommercesearch.api.controllers.ProductController.findSuggestions(version: Int = 1, q: String)
-GET           /v1/products                                               org.opencommercesearch.api.controllers.ProductController.search(version: Int = 1, q: String, site: String, outlet: Boolean ?= false)
+GET           /v1/products                                               org.opencommercesearch.api.controllers.ProductController.search(version: Int = 1, q: String, site: String, outlet: Boolean ?= false, spellCheck: String ?= "auto")
 GET           /v1/products/:id                                           org.opencommercesearch.api.controllers.ProductController.findById(version: Int = 1, id: String, site: String ?= null)
 GET           /v1/categories/:id/products                                org.opencommercesearch.api.controllers.ProductController.browse(version: Int = 1, site: String, id: String, outlet: Boolean ?= false)
 GET           /v1/brands/:brandId/products                               org.opencommercesearch.api.controllers.ProductController.browseBrand(version: Int = 1, site: String, brandId: String, outlet: Boolean ?= false)

--- a/opencommercesearch-api/test/org/opencommercesearch/api/controllers/FacetControllerSpec.scala
+++ b/opencommercesearch-api/test/org/opencommercesearch/api/controllers/FacetControllerSpec.scala
@@ -167,7 +167,7 @@ class FacetControllerSpec extends Specification with Mockito {
 
     // @todo test bulk update
     "send 400 when exceeding maximum facets an a bulk create" in new Facets {
-      running(FakeApplication(additionalConfiguration = Map("facet.maxUpdateBatchSize" -> 2))) {
+      running(FakeApplication(additionalConfiguration = Map("index.facet.batchsize.max" -> 2))) {
         val (updateResponse) = setupUpdate
         val expectedId = "1000"
         val expectedId2 = "1001"

--- a/opencommercesearch-sdk-java/src/main/java/org/opencommercesearch/client/impl/Metadata.java
+++ b/opencommercesearch-sdk-java/src/main/java/org/opencommercesearch/client/impl/Metadata.java
@@ -20,6 +20,7 @@ package org.opencommercesearch.client.impl;
 */
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.opencommercesearch.client.impl.spellcheck.SpellCheck;
 
 /**
  * Simple data holder for response metadata.
@@ -33,6 +34,7 @@ public class Metadata {
     private Facet[] facets;
     private BreadCrumb[] breadCrumbs;
     private String redirectUrl;
+    private SpellCheck spellCheck;
 
     /**
      * Gets the number of items found.
@@ -92,5 +94,11 @@ public class Metadata {
         this.breadCrumbs = breadCrumbs;
     }
 
+    public SpellCheck getSpellCheck() {
+        return spellCheck;
+    }
 
+    public void setSpellCheck(SpellCheck spellCheck) {
+        this.spellCheck = spellCheck;
+    }
 }

--- a/opencommercesearch-sdk-java/src/main/java/org/opencommercesearch/client/impl/spellcheck/SpellCheck.java
+++ b/opencommercesearch-sdk-java/src/main/java/org/opencommercesearch/client/impl/spellcheck/SpellCheck.java
@@ -1,0 +1,57 @@
+package org.opencommercesearch.client.impl.spellcheck;
+
+
+/**
+ * Represents spell check data returned from the API.
+ *
+ * @author jmendez
+ */
+public class SpellCheck {
+
+    private String collation;
+    private String correctedTerms;
+    private Term[] terms;
+    private Boolean similarResults;
+
+    public String getCorrectedTerms() {
+        return correctedTerms;
+    }
+
+    public void setCorrectedTerms(String correctedTerms) {
+        this.correctedTerms = correctedTerms;
+    }
+
+    public Term[] getTerms() {
+        return terms;
+    }
+
+    public void setTerms(Term[] terms) {
+        this.terms = terms;
+    }
+
+    /**
+     * If spellCheck was set to 'auto', product responses may contain exact or similar results.
+     * This method indicates if similar results are returned.
+     * <p/>
+     * For example, a search for "term1 term2" would usually return products that contain both
+     * 'term1' and 'term2'. If this method returns true, is because the original search did not produce
+     * any results and similar results were returned (if any). If set to true, products returned match 'token1' or
+     * 'token2', but not necessarily both of them as opposed to exact match results.
+     * @return Whether or not the results include similar results.
+     */
+    public Boolean getSimilarResults() {
+        return similarResults;
+    }
+
+    public void setSimilarResults(Boolean similarResults) {
+        this.similarResults = similarResults;
+    }
+
+    public String getCollation() {
+        return collation;
+    }
+
+    public void setCollation(String collation) {
+        this.collation = collation;
+    }
+}

--- a/opencommercesearch-sdk-java/src/main/java/org/opencommercesearch/client/impl/spellcheck/Term.java
+++ b/opencommercesearch-sdk-java/src/main/java/org/opencommercesearch/client/impl/spellcheck/Term.java
@@ -1,0 +1,56 @@
+package org.opencommercesearch.client.impl.spellcheck;
+
+
+/**
+ * A spell check term.
+ *
+ * @author jmendez
+ */
+public class Term {
+
+    private String term;
+    private int found;
+    private int startOffset;
+    private int endOffset;
+    private String[] suggestions;
+
+    public String getTerm() {
+        return term;
+    }
+
+    public void setTerm(String term) {
+        this.term = term;
+    }
+
+    public int getFound() {
+        return found;
+    }
+
+    public void setFound(int found) {
+        this.found = found;
+    }
+
+    public int getStartOffset() {
+        return startOffset;
+    }
+
+    public void setStartOffset(int startOffset) {
+        this.startOffset = startOffset;
+    }
+
+    public int getEndOffset() {
+        return endOffset;
+    }
+
+    public void setEndOffset(int endOffset) {
+        this.endOffset = endOffset;
+    }
+
+    public String[] getSuggestions() {
+        return suggestions;
+    }
+
+    public void setSuggestions(String[] suggestions) {
+        this.suggestions = suggestions;
+    }
+}

--- a/opencommercesearch-sdk-java/src/test/resources/data/searchResponse-EDR0001.json
+++ b/opencommercesearch-sdk-java/src/test/resources/data/searchResponse-EDR0001.json
@@ -1,0 +1,304 @@
+{
+    "metadata": {
+        "found": 1,
+        "time": 54
+    },
+    "products": [
+        {
+            "id": "EDR0001",
+            "title": "EC Bomber Men's Short-Sleeve T-Shirt",
+            "description": "<p>You could be arrested just for wearing this shirt. The Endurance Conspiracy EC Bomber T-shirt is just that fast...<br><br>Endurance Conspiracy is owned and managed by passionate endurance athletes who are in it for much more than a quick buck. EC is a company that has been built around the idea of an outdoor community. Its products are designed to be as Earth-friendly as possible in a fun-not-preachy way.\n</p>\n<p>All Endurance Conspiracy T-Shirts are made with 100% organic cotton and adhere to Bluesign resource productivity, consumer safety, air emission, water emission, and occupational health and safety standards.\n</p>\n<p>The Endurance Conspiracy Men’s EC Bomber T-Shirt is available in sizes S through XL and comes in Grass Stain and Lava.</p>",
+            "brand": {
+                "id": "100001471",
+                "name": "Endurance Conspiracy"
+            },
+            "detailImages": [
+                {
+                    "title": "Detail",
+                    "url": "/images/items/small/EDR/EDR0001/GRASTA_D1.jpg"
+                },
+                {
+                    "title": "Detail",
+                    "url": "/images/items/small/EDR/EDR0001/LV_D1.jpg"
+                }
+            ],
+            "features": [
+                {
+                    "name": "storecredits",
+                    "value": "0.0"
+                }
+            ],
+            "listRank": 2,
+            "customerReviews": {
+                "count": 0,
+                "average": 0,
+                "bayesianAverage": 2.5
+            },
+            "isOutOfStock": false,
+            "categories": [
+                {
+                    "id": "catb10001",
+                    "name": "rootNode",
+                    "seoUrlToken": "rootnode",
+                    "isRuleBased": false,
+                    "sites": [
+                        "bcs"
+                    ],
+                    "childCategories": [
+                        {
+                            "id": "bcsCat140000003",
+                            "name": "Bike",
+                            "seoUrlToken": "bike",
+                            "isRuleBased": false,
+                            "sites": [
+                                "bcs"
+                            ],
+                            "childCategories": [
+                                {
+                                    "id": "bcsCat141000004",
+                                    "name": "Men's Bike Clothing",
+                                    "seoUrlToken": "mens-bike-clothing",
+                                    "isRuleBased": false,
+                                    "sites": [
+                                        "bcs"
+                                    ],
+                                    "childCategories": [
+                                        {
+                                            "id": "bcsCat141100007",
+                                            "name": "Men's Bike Casual Wear",
+                                            "seoUrlToken": "mens-bike-casual-wear",
+                                            "isRuleBased": false,
+                                            "sites": [
+                                                "bcs"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "skus": [
+                {
+                    "id": "EDR0001-GRASTA-S",
+                    "season": "FW0",
+                    "year": "2013",
+                    "image": {
+                        "url": "/images/items/medium/EDR/EDR0001/GRASTA.jpg"
+                    },
+                    "isPastSeason": false,
+                    "color": {
+                        "name": "Grass Stain",
+                        "family": "green"
+                    },
+                    "title": "Grass Stain, S",
+                    "isRetail": true,
+                    "isCloseout": false,
+                    "isOutlet": false,
+                    "catalogs": [
+                        "competitivecyclist",
+                        "bcs"
+                    ],
+                    "listPrice": 29.95,
+                    "salePrice": 29.95,
+                    "discountPercent": 0,
+                    "stockLevel": 0,
+                    "url": "/endurance-conspiracy-ec-bomber-t-shirt-short-sleeve-mens",
+                    "allowBackorder": true
+                },
+                {
+                    "id": "EDR0001-LV-S",
+                    "season": "FW0",
+                    "year": "2013",
+                    "image": {
+                        "url": "/images/items/medium/EDR/EDR0001/LV.jpg"
+                    },
+                    "isPastSeason": false,
+                    "color": {
+                        "name": "Lava",
+                        "family": "red"
+                    },
+                    "title": "Lava, S",
+                    "isRetail": true,
+                    "isCloseout": false,
+                    "isOutlet": false,
+                    "catalogs": [
+                        "competitivecyclist",
+                        "bcs"
+                    ],
+                    "listPrice": 29.95,
+                    "salePrice": 29.95,
+                    "discountPercent": 0,
+                    "stockLevel": 0,
+                    "url": "/endurance-conspiracy-ec-bomber-t-shirt-short-sleeve-mens",
+                    "allowBackorder": true
+                },
+                {
+                    "id": "EDR0001-GRASTA-M",
+                    "season": "FW0",
+                    "year": "2013",
+                    "image": {
+                        "url": "/images/items/medium/EDR/EDR0001/GRASTA.jpg"
+                    },
+                    "isPastSeason": false,
+                    "color": {
+                        "name": "Grass Stain",
+                        "family": "green"
+                    },
+                    "title": "Grass Stain, M",
+                    "isRetail": true,
+                    "isCloseout": false,
+                    "isOutlet": false,
+                    "catalogs": [
+                        "competitivecyclist",
+                        "bcs"
+                    ],
+                    "listPrice": 29.95,
+                    "salePrice": 29.95,
+                    "discountPercent": 0,
+                    "stockLevel": 0,
+                    "url": "/endurance-conspiracy-ec-bomber-t-shirt-short-sleeve-mens",
+                    "allowBackorder": true
+                },
+                {
+                    "id": "EDR0001-LV-M",
+                    "season": "FW0",
+                    "year": "2013",
+                    "image": {
+                        "url": "/images/items/medium/EDR/EDR0001/LV.jpg"
+                    },
+                    "isPastSeason": false,
+                    "color": {
+                        "name": "Lava",
+                        "family": "red"
+                    },
+                    "title": "Lava, M",
+                    "isRetail": true,
+                    "isCloseout": false,
+                    "isOutlet": false,
+                    "catalogs": [
+                        "competitivecyclist",
+                        "bcs"
+                    ],
+                    "listPrice": 29.95,
+                    "salePrice": 29.95,
+                    "discountPercent": 0,
+                    "stockLevel": 0,
+                    "url": "/endurance-conspiracy-ec-bomber-t-shirt-short-sleeve-mens",
+                    "allowBackorder": true
+                },
+                {
+                    "id": "EDR0001-GRASTA-L",
+                    "season": "FW0",
+                    "year": "2013",
+                    "image": {
+                        "url": "/images/items/medium/EDR/EDR0001/GRASTA.jpg"
+                    },
+                    "isPastSeason": false,
+                    "color": {
+                        "name": "Grass Stain",
+                        "family": "green"
+                    },
+                    "title": "Grass Stain, L",
+                    "isRetail": true,
+                    "isCloseout": false,
+                    "isOutlet": false,
+                    "catalogs": [
+                        "competitivecyclist",
+                        "bcs"
+                    ],
+                    "listPrice": 29.95,
+                    "salePrice": 29.95,
+                    "discountPercent": 0,
+                    "stockLevel": 0,
+                    "url": "/endurance-conspiracy-ec-bomber-t-shirt-short-sleeve-mens",
+                    "allowBackorder": true
+                },
+                {
+                    "id": "EDR0001-LV-L",
+                    "season": "FW0",
+                    "year": "2013",
+                    "image": {
+                        "url": "/images/items/medium/EDR/EDR0001/LV.jpg"
+                    },
+                    "isPastSeason": false,
+                    "color": {
+                        "name": "Lava",
+                        "family": "red"
+                    },
+                    "title": "Lava, L",
+                    "isRetail": true,
+                    "isCloseout": false,
+                    "isOutlet": false,
+                    "catalogs": [
+                        "competitivecyclist",
+                        "bcs"
+                    ],
+                    "listPrice": 29.95,
+                    "salePrice": 29.95,
+                    "discountPercent": 0,
+                    "stockLevel": 0,
+                    "url": "/endurance-conspiracy-ec-bomber-t-shirt-short-sleeve-mens",
+                    "allowBackorder": true
+                },
+                {
+                    "id": "EDR0001-GRASTA-XL",
+                    "season": "FW0",
+                    "year": "2013",
+                    "image": {
+                        "url": "/images/items/medium/EDR/EDR0001/GRASTA.jpg"
+                    },
+                    "isPastSeason": false,
+                    "color": {
+                        "name": "Grass Stain",
+                        "family": "green"
+                    },
+                    "title": "Grass Stain, XL",
+                    "isRetail": true,
+                    "isCloseout": false,
+                    "isOutlet": false,
+                    "catalogs": [
+                        "competitivecyclist",
+                        "bcs"
+                    ],
+                    "listPrice": 29.95,
+                    "salePrice": 29.95,
+                    "discountPercent": 0,
+                    "stockLevel": 0,
+                    "url": "/endurance-conspiracy-ec-bomber-t-shirt-short-sleeve-mens",
+                    "allowBackorder": true
+                },
+                {
+                    "id": "EDR0001-LV-XL",
+                    "season": "FW0",
+                    "year": "2013",
+                    "image": {
+                        "url": "/images/items/medium/EDR/EDR0001/LV.jpg"
+                    },
+                    "isPastSeason": false,
+                    "color": {
+                        "name": "Lava",
+                        "family": "red"
+                    },
+                    "title": "Lava, XL",
+                    "isRetail": true,
+                    "isCloseout": false,
+                    "isOutlet": false,
+                    "catalogs": [
+                        "competitivecyclist",
+                        "bcs"
+                    ],
+                    "listPrice": 29.95,
+                    "salePrice": 29.95,
+                    "discountPercent": 0,
+                    "stockLevel": 0,
+                    "url": "/endurance-conspiracy-ec-bomber-t-shirt-short-sleeve-mens",
+                    "allowBackorder": true
+                }
+            ],
+            "isPackage": false,
+            "isOem": false
+        }
+    ]
+}

--- a/opencommercesearch-sdk-java/src/test/resources/data/spellcheck.json
+++ b/opencommercesearch-sdk-java/src/test/resources/data/spellcheck.json
@@ -1,0 +1,48 @@
+{
+    "metadata": {
+        "found": 0,
+        "time": 120,
+        "spellCheck": {
+            "terms": [
+                {
+                    "term": "nort",
+                    "found": 10,
+                    "startOffset": 0,
+                    "endOffset": 4,
+                    "suggestions": [
+                        "north",
+                        "norte",
+                        "nord",
+                        "norm",
+                        "nora",
+                        "not",
+                        "nrt",
+                        "none",
+                        "next",
+                        "nose"
+                    ]
+                },
+                {
+                    "term": "fase",
+                    "found": 10,
+                    "startOffset": 5,
+                    "endOffset": 9,
+                    "suggestions": [
+                        "face",
+                        "fast",
+                        "fade",
+                        "fave",
+                        "fuse",
+                        "fate",
+                        "fame",
+                        "faye",
+                        "faze",
+                        "fake"
+                    ]
+                }
+            ],
+            "collation": "north face"
+        }
+    },
+    "message": "No products found"
+}


### PR DESCRIPTION
Support for spellchecking. Three modes supported: 'auto' -> retry an empty results search with collated terms, 'yes' -> simply return the collation and term suggestions to the client, 'no' -> no spellchecking

Also, simplifying search response creation.
