### PR TITLE
fix issue with stemmer dictionary - for MASTER

### DIFF
--- a/opencommercesearch-atg-common/src/main/config/solr/product_catalog/conf/stem/en_US.txt
+++ b/opencommercesearch-atg-common/src/main/config/solr/product_catalog/conf/stem/en_US.txt
@@ -6,6 +6,6 @@ swum	swim
 north	north
 device	device
 vs	vs
-men     man
+men	man
 mens	man
 layers	layer


### PR DESCRIPTION
All entries should be separated by tab, not by spaces.