### PR TITLE
changes to support replacing $YEAR & $SEASON variables

### DIFF
--- a/opencommercesearch-atg-common/src/main/config/solr/product_catalog/conf/solrconfig.xml
+++ b/opencommercesearch-atg-common/src/main/config/solr/product_catalog/conf/solrconfig.xml
@@ -90,12 +90,8 @@
 
     <searchComponent name="expandall" class="solr.ExpandAllComponent" />
 
-  <!-- Rule manager component - Filters, boosts or modifies results based on pre-defined business rules -->
-  <searchComponent name="ruleManager" class="solr.RuleManagerComponent">
-    <!--The base name of the rule and facet cores (i.e. if your core is called rulePreview_en, set it to -->
-    <str name="facetsCore">facets</str>
-    <str name="rulesCore">rule</str>
-  </searchComponent>
+  <xi:include href="xinclude/rule-manager.xml" parse="xml"
+    xmlns:xi="http://www.w3.org/2001/XInclude" />
 
   <xi:include href="xinclude/custom-components.xml" parse="xml"
     xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/opencommercesearch-atg-common/src/main/config/solr/product_catalog/conf/xinclude/rule-manager.xml
+++ b/opencommercesearch-atg-common/src/main/config/solr/product_catalog/conf/xinclude/rule-manager.xml
@@ -1,0 +1,6 @@
+  <!-- Rule manager component - Filters, boosts or modifies results based on pre-defined business rules -->
+  <searchComponent name="ruleManager" class="solr.RuleManagerComponent">
+    <!--The base name of the rule and facet cores (i.e. if your core is called rulePreview_en, set it to -->
+    <str name="facetsCore">facets</str>
+    <str name="rulesCore">rule</str>
+  </searchComponent>

--- a/opencommercesearch-atg-common/src/main/java/org/opencommercesearch/RulesBuilder.java
+++ b/opencommercesearch-atg-common/src/main/java/org/opencommercesearch/RulesBuilder.java
@@ -22,11 +22,8 @@ package org.opencommercesearch;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.solr.client.solrj.util.ClientUtils;
-import org.opencommercesearch.repository.CategoryProperty;
 import org.opencommercesearch.repository.RankingRuleProperty;
 import org.opencommercesearch.repository.RuleBasedCategoryProperty;
 import org.opencommercesearch.repository.RuleExpressionProperty;
@@ -109,6 +106,25 @@ public class RulesBuilder extends GenericService {
         KEYWORD {
             public String toFilter(String ruleValue, Locale locale, Repository productCatalog) {
                 return new StringBuilder().append("keyword:").append(ClientUtils.escapeQueryChars(ruleValue)).toString();
+            }
+        },
+        SEASON {
+            public String toFilter(String ruleValue, Locale locale, Repository productCatalog) {
+                StringBuilder builder = new StringBuilder().append("season:");
+                String season = ruleValue;
+                if ("current".equalsIgnoreCase(ruleValue)) {
+                    season = "$SEASON";
+                }
+                return builder.append(season).toString();
+            }
+        },
+        YEAR {
+            public String toFilter(String ruleValue, Locale locale, Repository productCatalog) {
+                String year = ruleValue;
+                if ("current".equalsIgnoreCase(ruleValue)) {
+                   year = "$YEAR";
+                }
+                return new StringBuilder().append("year:").append(year).toString();
             }
         };
 

--- a/opencommercesearch-atg-common/src/test/java/org/opencommercesearch/RulesBuilderTest.java
+++ b/opencommercesearch-atg-common/src/test/java/org/opencommercesearch/RulesBuilderTest.java
@@ -260,6 +260,54 @@ public class RulesBuilderTest {
          String builder = rulesBuilder.buildRulesFilter("ruleCategory", Locale.US);
 
          assertEquals("(ancestorCategoryId:ruleCategory)",builder);
-     }    
+     }  
+     
+     @Test
+     public void testBuildSimpleSeasonRule() throws RepositoryException {
+
+         List<RepositoryItem> expresionList = new ArrayList<RepositoryItem>();
+         expresionList.add(mockRule("season", 1, "SS0", null));
+         mockBaseRule(productCatalog, expresionList, mock(RepositoryItem.class), "ruleCategory", true);
+
+         String builder = rulesBuilder.buildRulesFilter("ruleCategory", Locale.US);
+
+         assertEquals("(ancestorCategoryId:ruleCategory) OR (season:SS0)", builder);
+     }
+     
+     @Test
+     public void testBuildSeasonRuleCurrent() throws RepositoryException {
+
+         List<RepositoryItem> expresionList = new ArrayList<RepositoryItem>();
+         expresionList.add(mockRule("season", 1, "current", null));
+         mockBaseRule(productCatalog, expresionList, mock(RepositoryItem.class), "ruleCategory", true);
+
+         String builder = rulesBuilder.buildRulesFilter("ruleCategory", Locale.US);
+
+         assertEquals("(ancestorCategoryId:ruleCategory) OR (season:$SEASON)", builder);
+     }
+     
+     @Test
+     public void testBuildSimpleYearRule() throws RepositoryException {
+
+         List<RepositoryItem> expresionList = new ArrayList<RepositoryItem>();
+         expresionList.add(mockRule("year", 1, "2015", null));
+         mockBaseRule(productCatalog, expresionList, mock(RepositoryItem.class), "ruleCategory", true);
+
+         String builder = rulesBuilder.buildRulesFilter("ruleCategory", Locale.US);
+
+         assertEquals("(ancestorCategoryId:ruleCategory) OR (year:2015)", builder);
+     }
+     
+     @Test
+     public void testBuildYearRuleCurrent() throws RepositoryException {
+
+         List<RepositoryItem> expresionList = new ArrayList<RepositoryItem>();
+         expresionList.add(mockRule("year", 1, "current", null));
+         mockBaseRule(productCatalog, expresionList, mock(RepositoryItem.class), "ruleCategory", true);
+
+         String builder = rulesBuilder.buildRulesFilter("ruleCategory", Locale.US);
+
+         assertEquals("(ancestorCategoryId:ruleCategory) OR (year:$YEAR)", builder);
+     }
 
 }

--- a/opencommercesearch-solr/src/main/java/org/apache/solr/common/params/MergedSolrParams.java
+++ b/opencommercesearch-solr/src/main/java/org/apache/solr/common/params/MergedSolrParams.java
@@ -19,6 +19,7 @@ package org.apache.solr.common.params;
 * under the License.
 */
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.common.util.IteratorChain;
 
@@ -190,6 +191,22 @@ public class MergedSolrParams extends SolrQuery {
         c.addIterator(defaults.getParameterNamesIterator());
         c.addIterator(values.keySet().iterator());
         return c;
+    }
+
+    public void replaceVariable(String param, String varName, String varValue){
+        String[] entries = defaults.getParams(param);
+        if (entries != null) {
+           for(int i = 0; i < entries.length; i++) {
+               entries[i] = StringUtils.replace(entries[i], varName, varValue);
+           }
+        }
+
+        entries = values.get(param);
+        if (entries != null) {
+            for(int i = 0; i < entries.length; i++) {
+                entries[i] = StringUtils.replace(entries[i], varName, varValue);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
changes to support replacing $YEAR & $SEASON variables in runtime at rule manager component when applying boost functions in ranking rules or when browsing a rule category