### PR TITLE
[US27522] Defect: CC plp should have 42 items, not 40.

### DIFF
--- a/opencommercesearch-api/app/org/opencommercesearch/api/Global.scala
+++ b/opencommercesearch-api/app/org/opencommercesearch/api/Global.scala
@@ -54,7 +54,7 @@ object Global extends WithFilters(new StatsdFilter(), new GzipFilter(), AccessLo
   lazy val FacetPublicCollection = getConfig("public.collection.facet", "facetsPublic") 
   lazy val SuggestCollection = getConfig("public.collection.suggest", "autocomplete")
   lazy val CategoryCacheTtl = getConfig("category.cache.ttl", 60 * 10)
-  lazy val MaxPaginationLimit = getConfig("pagination.limit.max", 40)
+  lazy val MaxPaginationLimit = getConfig("pagination.limit.max", 60)
   lazy val MaxBrandPaginationLimit = getConfig("pagination.limit.max", 3000)
   lazy val DefaultPaginationLimit = getConfig("pagination.limit.default", 10)
   lazy val MaxFacetPaginationLimit = getConfig("facet.pagination.limit.max", 5000)


### PR DESCRIPTION
Changed default value of pagination.limit.max on Global.scala from 40 to 60.