### PR TITLE
Partial Product Updates

### DIFF
--- a/opencommercesearch-api/app/org/opencommercesearch/api/Global.scala
+++ b/opencommercesearch-api/app/org/opencommercesearch/api/Global.scala
@@ -62,6 +62,7 @@ object Global extends WithFilters(new StatsdFilter(), new GzipFilter(), AccessLo
   lazy val MinSuggestQuerySize = getConfig("suggester.query.size.min", 2)
   lazy val IndexOemProductsEnabled = getConfig("index.product.oem.enabled", default = false)
   lazy val FilterLiveProductsEnabled = getConfig("product.filter.live", default = false)
+  lazy val MaxProductsLimit = getConfig("product.limit.max", 20)
   lazy val ProductAvailabilityStatusSummary = availabilityStatusSummaryConfig
   lazy val SearchMinimumMatch = getConfig("search.minimummatch", "2<-1 3<-2 5<80%")
 

--- a/opencommercesearch-api/app/org/opencommercesearch/api/service/Storage.scala
+++ b/opencommercesearch-api/app/org/opencommercesearch/api/service/Storage.scala
@@ -91,6 +91,14 @@ trait Storage[T] {
   def saveProduct(product: Product*) : Future[T]
 
   /**
+   * Update parts of a product. For the moment only the
+   * skus.countries update is supported
+   * @param product is one or more products to update
+   * @return the results of writing the last product update
+   */
+  def updateProductFields(product: Product*) : Future[T]
+
+  /**
    * Delete the product with the given id. Returns the result of the deleting the product
    * @param id is of the product to delete
    * @return the result of deleting the product

--- a/opencommercesearch-api/conf/routes
+++ b/opencommercesearch-api/conf/routes
@@ -29,6 +29,7 @@ GET           /v1/brands/:brandId/products                               org.ope
 GET           /v1/brands/:brandId/categories/:categoryId/products        org.opencommercesearch.api.controllers.ProductController.browseBrandCategory(version: Int = 1, site: String, brandId: String, categoryId: String, outlet: Boolean ?= false)
 GET           /v1/products/:id/content                                   org.opencommercesearch.api.controllers.ProductController.findProductContent(version: Int = 1, id: String, site: String ?= null)
 PUT           /v1/products                                               org.opencommercesearch.api.controllers.ProductController.bulkCreateOrUpdate(version: Int = 1)
+PUT           /v1/products/fields                                        org.opencommercesearch.api.controllers.ProductController.bulkUpdateFields(version: Int = 1)
 PUT           /v1/products/content                                       org.opencommercesearch.api.controllers.ProductController.bulkCreateOrUpdateProductContent(version: Int = 1, site: String ?= null)
 DELETE        /v1/products                                               org.opencommercesearch.api.controllers.ProductController.deleteByTimestamp(version: Int = 1, feedTimestamp: Long)
 DELETE        /v1/products/:id                                           org.opencommercesearch.api.controllers.ProductController.deleteById(version: Int = 1, id: String)

--- a/opencommercesearch-atg-common/src/main/config/org/opencommercesearch/api/ProductService.properties
+++ b/opencommercesearch-atg-common/src/main/config/org/opencommercesearch/api/ProductService.properties
@@ -8,7 +8,8 @@ endpoints=brands=/v1/brands, \
     products=/v1/products, \
     categories=/v1/categories, \
     facets=/v1/facets, \
-    product_content=/v1/products/${id}/content
+    product_content=/v1/products/${id}/content, \
+    product_field_update=/v1/products/fields
 
 httpSettings=initialConnections=20,\
     maxConnectionsPerHost=20,\

--- a/opencommercesearch-atg-common/src/main/java/org/opencommercesearch/api/ProductService.java
+++ b/opencommercesearch-atg-common/src/main/java/org/opencommercesearch/api/ProductService.java
@@ -40,7 +40,8 @@ public class ProductService extends GenericService {
         PRODUCTS,
         CATEGORIES,
         FACETS,
-        PRODUCT_CONTENT;
+        PRODUCT_CONTENT,
+        PRODUCT_FIELD_UPDATE;
 
         private String lowerCaseName;
 

--- a/opencommercesearch-atg-common/src/main/java/org/opencommercesearch/feed/SearchFeed.java
+++ b/opencommercesearch-atg-common/src/main/java/org/opencommercesearch/feed/SearchFeed.java
@@ -80,7 +80,7 @@ public abstract class SearchFeed extends GenericService {
     private int indexBatchSize;
     private ProductService productService;
     private ObjectMapper mapper;
-    private String endpointUrl;
+    protected String endpointUrl;
     private int workerCount;
     private ExecutorService productTaskExecutor;
     private AtomicInteger processedProductCount;


### PR DESCRIPTION
Adding support for partial updates to PUT Product documents. Currently we only support updating the skus.countries section

Adding limit to the find product by id endpoint to a max of 20.