### PR TITLE
Add limitation for the length of queries and filter queries.

### DIFF
--- a/opencommercesearch-api/app/org/opencommercesearch/api/Global.scala
+++ b/opencommercesearch-api/app/org/opencommercesearch/api/Global.scala
@@ -65,6 +65,8 @@ object Global extends WithFilters(new StatsdFilter(), new GzipFilter(), AccessLo
   lazy val MaxProductsLimit = getConfig("product.limit.max", 20)
   lazy val ProductAvailabilityStatusSummary = availabilityStatusSummaryConfig
   lazy val SearchMinimumMatch = getConfig("search.minimummatch", "2<-1 3<-2 5<80%")
+  lazy val MaxQueryLength = getConfig("request.query.length.max", 1000)
+  lazy val MaxFilterQueryLength = getConfig("request.filterquery.length.max", 2000)
 
   // @todo evaluate using dependency injection, for the moment lets be pragmatic
   private var _solrServer: AsyncSolrServer = null


### PR DESCRIPTION
This configurable limitation allows to protect to hackers attacks when they try to overload the system with very long filter queries.